### PR TITLE
Add viewport meta tag in HTML to make the widget fullscreen

### DIFF
--- a/edgetier_chat_widget_demo/assets/www/chat-window-demo.html
+++ b/edgetier_chat_widget_demo/assets/www/chat-window-demo.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Customer Support Chat</title>
         <style>
             html,

--- a/edgetier_chat_widget_demo/lib/main.dart
+++ b/edgetier_chat_widget_demo/lib/main.dart
@@ -178,10 +178,7 @@ Failed to load chat widget: ${error.errorType}
       body:
           controller == null
               ? CircularProgressIndicator()
-              : SizedBox(
-                height: 300,
-                child: WebViewWidget(controller: controller!),
-              ),
+              : SizedBox.expand(child: WebViewWidget(controller: controller!)),
     );
   }
 }


### PR DESCRIPTION
I added the viewport `meta` tag to the `head` of the HTML to the scale would be correct in the WebView. I also resized the `SizedBox` to use the full available height.