### PR TITLE
Show a message when chat is unavailable

### DIFF
--- a/edgetier_chat_widget_demo/assets/www/chat-window-demo.html
+++ b/edgetier_chat_widget_demo/assets/www/chat-window-demo.html
@@ -40,7 +40,7 @@
                         return;
                     }
 
-                    if (!data.isavailable) {
+                    if (!data.isAvailable) {
                         const newElement = document.createElement("p");
                         newElement.textContent = "The widget is unavailable. There are currently no agents online.";
                         document.body.appendChild(newElement);


### PR DESCRIPTION
If the widget is unavailable, add an element to the HTML with a message explaining there are no agents online.