### PR TITLE
Add launch configuration for VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Chat Widget Demo",
+            "cwd": "edgetier_chat_widget_demo",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "Chat Widget Demo (profile mode)",
+            "cwd": "edgetier_chat_widget_demo",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "Chat Widget Demo (release mode)",
+            "cwd": "edgetier_chat_widget_demo",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        }
+    ]
+}


### PR DESCRIPTION
Add a default Flutter launch configuration for VSCode. Without this, running the app becomes a bit quirky: you have to select a `main.dart` and then hit "Run" in VSCode.

With this, you already have all the Run/Debug configurations you need.